### PR TITLE
Remove useless or unused shebang lines

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # SHYBRID documentation build configuration file, created by

--- a/hybridizer/hybrid.py
+++ b/hybridizer/hybrid.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 SHYBRID

--- a/hybridizer/io.py
+++ b/hybridizer/io.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 SHYBRID

--- a/hybridizer/probes.py
+++ b/hybridizer/probes.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 SHYBRID

--- a/hybridizer/shybrid.py
+++ b/hybridizer/shybrid.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Created on Fri Sep 28 13:36:01 2018

--- a/hybridizer/spikes.py
+++ b/hybridizer/spikes.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 SHYBRID

--- a/hybridizer/threads.py
+++ b/hybridizer/threads.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 SHYBRID

--- a/hybridizer/validation.py
+++ b/hybridizer/validation.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 SHYBRID

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from setuptools import setup
 
 with open("README.md", "r") as fh:


### PR DESCRIPTION
The first commit removes shebangs (`#!`) from non-script sources.

These files have no `if __name__ == "__main__"` or similar and no interesting side effects. They are only meant to be imported. Therefore, a shebang line is not useful.

----

The second commit removes shebangs from non-executable scripts.

These *could* use a shebang line, but the executable bit is not set, so it will never be useful.
    
Leaving the shebang lines and making the files executable would be an alternative, but it doesn’t seem necessary:
    
 - For `setup.py`, the traditional invocation is something like `python3 setup.py …`, and this will work fine without a shebang.
    
 - For `hybridizer/shybrid.py`, end-users will run the entry point script `shybrid` generated by setuptools instead, and developers can still run `PYTHONPATH="${PWD}" python3 hybridizer/shybrid.py` or `PYTHONPATH="${PWD}" python3 -m hybridizer.shybrid` if they like.